### PR TITLE
Better Server Shutdown and Logger Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,10 +151,21 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "clap",
+ "ctrlc",
  "env_logger",
  "log",
  "tempdir",
  "thiserror",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -221,6 +250,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ about = "A B-Tree storage engine."
 [dependencies]
 bincode = { version = "2.0.1", features = ["derive"] }
 clap = { version = "4.5.37", features = ["derive"] }
+ctrlc = "3.4.6"
 env_logger = "0.11.8"
 log = "0.4.27"
 thiserror = "2.0.12"

--- a/src/protocol/server.rs
+++ b/src/protocol/server.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
 };
 
-use log::{info, warn};
+use log::info;
 
 use crate::{
     Command,

--- a/src/protocol/thread.rs
+++ b/src/protocol/thread.rs
@@ -69,6 +69,7 @@ impl Worker {
                     }
                     Err(_) => {
                         debug!("worker {id} disconnected!");
+                        break;
                     }
                 }
             }

--- a/src/storage/log.rs
+++ b/src/storage/log.rs
@@ -26,7 +26,6 @@
 //! - [`protocol`](crate::protocol): Client commands that trigger WAL writes.
 
 use std::{
-    collections::VecDeque,
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom, Write},
     path::PathBuf,

--- a/src/storage/log.rs
+++ b/src/storage/log.rs
@@ -28,7 +28,7 @@
 use std::{
     collections::VecDeque,
     fs::{File, OpenOptions},
-    io::{BufReader, BufWriter, Seek, Write},
+    io::{BufReader, BufWriter, Seek, SeekFrom, Write},
     path::PathBuf,
 };
 
@@ -37,10 +37,13 @@ use bincode::{
     config::{BigEndian, Configuration, Fixint},
     decode_from_reader, encode_into_std_write,
 };
-use log::{info, trace};
+use log::{debug, info, trace};
 
 use super::{LoggerError, Row, StorageError, btree::BTree, pager::Pager};
 
+/// Entry recorded in time for easy recovery; Any state changes
+/// is tracked here and stored before the change is fully
+/// written to the on-disk structure.
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum LogEntry {
     Insert(Vec<u8>),
@@ -49,55 +52,74 @@ pub enum LogEntry {
     GlobalCheckpoint,
 }
 
+/// Tracks state changes before batch-processing permanent
+/// on-disk writes.
 pub struct Logger {
     config: Configuration<BigEndian, Fixint>,
-    entries: VecDeque<LogEntry>,
+    entries: Vec<(u64, usize)>,
     pager: Pager,
     writer: BufWriter<File>,
+    path: PathBuf,
 }
 
-pub const COMPACTION_THRESHOLD: usize = 100;
-
 impl Logger {
-    pub fn open(path: PathBuf, pager: Pager) -> Result<Self, StorageError> {
+    pub fn open(path: PathBuf, mut pager: Pager) -> Result<Self, StorageError> {
         let log = OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
             .truncate(false)
-            .open(path)
+            .open(&path)
             .map_err(|e| StorageError::Logger {
                 cause: LoggerError::Io(e),
             })?;
         let config = bincode::config::standard()
             .with_big_endian()
             .with_fixed_int_encoding();
-
         let mut reader = BufReader::new(log);
+        pager.commit(false);
 
-        let mut entries = VecDeque::new();
+        // Apply previous state.
+        let mut btree = BTree::new(&mut pager);
+        let mut entries = Vec::new();
         loop {
+            let offset = reader.stream_position().map_err(|e| StorageError::Logger {
+                cause: LoggerError::Io(e),
+            })?;
             let entry: Result<LogEntry, _> = decode_from_reader(&mut reader, config);
             match entry {
-                Ok(LogEntry::GlobalCheckpoint) => entries.clear(),
-                Ok(log) => entries.push_back(log),
+                Ok(log) => {
+                    let row: Row = match log {
+                        LogEntry::Update(ref bytes)
+                        | LogEntry::Insert(ref bytes)
+                        | LogEntry::Delete(ref bytes) => bytes.as_slice().try_into()?,
+                        LogEntry::GlobalCheckpoint => continue,
+                    };
+                    entries.push((offset, row.id()));
+
+                    match log {
+                        LogEntry::Update(_) => {
+                            btree.update(row)?;
+                        }
+                        LogEntry::Insert(_) => {
+                            btree.insert(row)?;
+                        }
+                        LogEntry::Delete(_) => {
+                            btree.delete(row)?;
+                        }
+                        _ => unreachable!("only row tasks should be handled here"),
+                    };
+                }
                 Err(_) => break,
             }
         }
-        let pos = reader.stream_position().map_err(|e| StorageError::Logger {
-            cause: LoggerError::Io(e),
-        })?;
-        let mut inner = reader.into_inner();
-        inner
-            .seek(std::io::SeekFrom::Start(pos))
-            .map_err(|e| StorageError::Logger {
-                cause: LoggerError::Io(e),
-            })?;
 
+        let inner = reader.into_inner();
         Ok(Self {
             config,
             entries,
             pager,
+            path,
             writer: BufWriter::new(inner),
         })
     }
@@ -106,62 +128,66 @@ impl Logger {
         &mut self.pager
     }
 
+    /// Writes an entry to the Write-Ahead log. If a [LogEntry::GlobalCheckpoint] is
+    /// logged all previous entries are applied permanently and cleared.
     pub fn log(&mut self, entry: LogEntry) -> Result<(), StorageError> {
+        let row: Row = match entry {
+            LogEntry::GlobalCheckpoint => return self.compact(),
+            LogEntry::Update(ref bytes)
+            | LogEntry::Insert(ref bytes)
+            | LogEntry::Delete(ref bytes) => bytes.as_slice().try_into()?,
+        };
+        let id = row.id();
+
+        debug!("attempting to apply entry - {entry:?}");
+        let mut btree = BTree::new(&mut self.pager);
+        match entry {
+            LogEntry::Update(_) => {
+                btree.update(row)?;
+            }
+            LogEntry::Insert(_) => {
+                btree.insert(row)?;
+            }
+            LogEntry::Delete(_) => {
+                btree.delete(row)?;
+            }
+            _ => unreachable!("only row tasks should be handled here"),
+        };
+
         info!("entry logged: {entry:?}");
-        encode_into_std_write(entry.clone(), &mut self.writer, self.config).map_err(|e| {
+        let offset = self
+            .writer
+            .stream_position()
+            .map_err(|e| StorageError::Logger {
+                cause: LoggerError::Io(e),
+            })?;
+        encode_into_std_write(entry, &mut self.writer, self.config).map_err(|e| {
             StorageError::Logger {
                 cause: LoggerError::Serialize(e),
             }
         })?;
-
         self.writer.flush().map_err(|e| StorageError::Logger {
             cause: LoggerError::Io(e),
         })?;
 
-        if entry == LogEntry::GlobalCheckpoint {
-            self.compact(true)?;
-        } else {
-            self.entries.push_back(entry);
-            if self.entries.len() >= COMPACTION_THRESHOLD {
-                return self.log(LogEntry::GlobalCheckpoint);
-            }
-        }
+        self.entries.push((offset, id));
+
         Ok(())
     }
 
-    fn compact(&mut self, clear: bool) -> Result<(), StorageError> {
+    fn compact(&mut self) -> Result<(), StorageError> {
         info!("flushing {} entries", self.entries.len());
         trace!("entries: {:?}", self.entries);
 
-        let mut entries = if clear {
-            let entries = self.entries.clone();
-            self.entries.clear();
-            entries
-        } else {
-            self.entries.clone()
-        };
-
-        while let Some(entry) = entries.pop_front() {
-            let mut btree = BTree::new(&mut self.pager);
-
-            match entry {
-                LogEntry::Insert(items) => {
-                    let row: Row = items.as_slice().try_into()?;
-                    btree.insert(row)?;
-                }
-                LogEntry::Delete(items) => {
-                    let row: Row = items.as_slice().try_into()?;
-                    btree.delete(row)?;
-                }
-                LogEntry::Update(items) => {
-                    let row: Row = items.as_slice().try_into()?;
-                    btree.update(row)?;
-                }
-                LogEntry::GlobalCheckpoint => {}
-            }
-        }
-
+        // Apply in-memory state
+        self.pager.commit(true);
         self.pager.flush();
+        self.pager.commit(false);
+
+        // Clear applied entries
+        // NOTE: This assumes the in-memory entries
+        // have already been applied to the pager.
+        self.entries.clear();
         self.writer.flush().map_err(|e| StorageError::Logger {
             cause: LoggerError::Io(e),
         })?;
@@ -179,8 +205,32 @@ impl Logger {
     }
 
     #[allow(dead_code)]
-    fn list_entries(&mut self) -> Result<Vec<LogEntry>, StorageError> {
-        Ok(self.entries.iter().cloned().collect::<Vec<LogEntry>>())
+    fn list_entries(&self) -> Result<Vec<LogEntry>, StorageError> {
+        let log = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&self.path)
+            .map_err(|e| StorageError::Logger {
+                cause: LoggerError::Io(e),
+            })?;
+        let mut reader = BufReader::new(log);
+        let mut out = Vec::new();
+
+        for (offset, _) in self.entries.iter() {
+            reader
+                .seek(SeekFrom::Start(*offset))
+                .map_err(|e| StorageError::Logger {
+                    cause: LoggerError::Io(e),
+                })?;
+            let entry: LogEntry =
+                decode_from_reader(&mut reader, self.config).map_err(|e| StorageError::Logger {
+                    cause: LoggerError::Deserialize(e),
+                })?;
+            out.push(entry);
+        }
+        Ok(out)
     }
 }
 
@@ -293,5 +343,25 @@ mod tests {
         let f = File::open(temp.path().join("wal.log")).unwrap();
         let new_len = f.metadata().unwrap().len();
         assert!(new_len < len);
+    }
+
+    #[test]
+    #[should_panic(expected = "Duplicate")]
+    fn logger_pager_state() {
+        let temp = TempDir::new("log").unwrap();
+        let pager = Pager::open(temp.path().join("cryo.db")).unwrap();
+        let mut logger = Logger::open(temp.path().join("wal.log"), pager).unwrap();
+
+        let row = Row::new(10, RowType::Leaf);
+        logger
+            .log(LogEntry::Insert(row.as_bytes().to_vec()))
+            .unwrap();
+        drop(logger);
+
+        let pager = Pager::open(temp.path().join("cryo.db")).unwrap();
+        let mut logger = Logger::open(temp.path().join("wal.log"), pager).unwrap();
+        logger
+            .log(LogEntry::Insert(row.as_bytes().to_vec()))
+            .unwrap();
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -72,6 +72,10 @@ pub enum PageError {
 pub enum PagerError {
     #[error("io error; {0}")]
     Io(#[from] io::Error),
+    #[error("accessed out of bounds memory")]
+    OutOfBounds,
+    #[error("poisoned state")]
+    PoisonedState,
 }
 
 #[derive(Debug, Error)]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -84,6 +84,8 @@ pub enum LoggerError {
     Io(#[from] io::Error),
     #[error("serialize error: {0}")]
     Serialize(#[from] bincode::error::EncodeError),
+    #[error("deserialize error: {0}")]
+    Deserialize(#[from] bincode::error::DecodeError),
 }
 
 #[derive(Debug, Error)]

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -65,7 +65,7 @@ pub enum PageType {
 /// Representation of Page
 ///
 /// Pages are the core unit of IO operation in the database.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Page {
     pub _type: PageType,
     pub offset: usize,

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -27,6 +27,8 @@
 //! - [`Row`]: Encapsulates record stored within a page.
 //! - [`StorageEngine`](crate::storage::StorageEngine): Issues operations that ultimately read/write to pages.
 
+use log::info;
+
 use super::{
     PageError, Row, StorageError,
     row::{BASE_LEAF_ROW_SIZE, INTERNAL_ROW_SIZE},
@@ -82,6 +84,38 @@ impl Page {
             rows,
             size,
         }
+    }
+
+    /// Attempts to create a new page from a byte
+    /// array.
+    pub fn from_u8(value: &[u8]) -> Result<Self, StorageError> {
+        let _type: PageType = value[PAGE_TYPE].into();
+        let is_root = value[PAGE_HAS_PARENT] == IS_ROOT;
+        let parent = if is_root {
+            None
+        } else {
+            Some(usize::from_ne_bytes(
+                value[PAGE_PARENT..PAGE_ROWS]
+                    .try_into()
+                    .expect("should be expected byte size"),
+            ))
+        };
+        let num_rows = usize::from_ne_bytes(
+            value[PAGE_ROWS..PAGE_HEADER_SIZE]
+                .try_into()
+                .expect("should be expected byte size"),
+        );
+        info!("Allocating space for {num_rows} rows.");
+        let mut rows = Vec::with_capacity(num_rows);
+        let mut offset = PAGE_HEADER_SIZE;
+
+        for _ in 0..num_rows {
+            let row: Row = (&value[offset..]).try_into()?;
+            offset += row.as_bytes().len();
+            rows.push(row);
+        }
+
+        Ok(Page::new(_type, parent, rows, offset - PAGE_HEADER_SIZE))
     }
 
     /// Select all rows present in the page.
@@ -274,32 +308,15 @@ impl TryFrom<[u8; PAGE_SIZE]> for Page {
     type Error = StorageError;
 
     fn try_from(value: [u8; PAGE_SIZE]) -> Result<Self, Self::Error> {
-        let _type: PageType = value[PAGE_TYPE].into();
-        let is_root = value[PAGE_HAS_PARENT] == IS_ROOT;
-        let parent = if is_root {
-            None
-        } else {
-            Some(usize::from_ne_bytes(
-                value[PAGE_PARENT..PAGE_ROWS]
-                    .try_into()
-                    .expect("should be expected byte size"),
-            ))
-        };
-        let num_rows = usize::from_ne_bytes(
-            value[PAGE_ROWS..PAGE_HEADER_SIZE]
-                .try_into()
-                .expect("should be expected byte size"),
-        );
-        let mut rows = Vec::with_capacity(num_rows);
-        let mut offset = PAGE_HEADER_SIZE;
+        Page::from_u8(&value)
+    }
+}
 
-        for _ in 0..num_rows {
-            let row: Row = (&value[offset..]).try_into()?;
-            offset += row.as_bytes().len();
-            rows.push(row);
-        }
+impl TryFrom<&[u8]> for Page {
+    type Error = StorageError;
 
-        Ok(Page::new(_type, parent, rows, offset - PAGE_HEADER_SIZE))
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Page::from_u8(value)
     }
 }
 


### PR DESCRIPTION
- **refactor: allow changing the number of cached pages**
- **refactor: add `from_u8` function**
- **refactor: modify pager to track pages in memory by default**
- **refactor: logger ensures in-memory pager is always up to date**
- **refactor: only compact log when server is dropped**
- **refactor: allow users to shutdown server with Ctrl-C**
- **chore: remove unneeded imports**
